### PR TITLE
Fix clients base uri according Azure Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Application Options:
   -v, --verbose                            verbose mode [$VERBOSE]
       --log.json                           Switch log output to json format [$LOG_JSON]
       --azure-environment=                 Azure environment name (default: AZUREPUBLICCLOUD) [$AZURE_ENVIRONMENT]
+      --azure-ad-resource-url=             Specifies the AAD resource ID to use. If not set, it defaults to ResourceManagerEndpoint for operations with Azure Resource Manager [$AZURE_AD_RESOURCE]
       --concurrency.subscription=          Concurrent subscription fetches (default: 5) [$CONCURRENCY_SUBSCRIPTION]
       --concurrency.subscription.resource= Concurrent requests per resource (inside subscription requests) (default:
                                            10) [$CONCURRENCY_SUBSCRIPTION_RESOURCE]
@@ -137,10 +138,10 @@ Azure Redis metrics
   metrics_path: /probe/metrics/list
   params:
     name: ["my_own_metric_name"]
-    subscription: 
+    subscription:
     - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     filter: ["resourceType eq 'Microsoft.Cache/Redis'"]
-    metric:       
+    metric:
     - connectedclients
     - totalcommandsprocessed
     - cachehits
@@ -162,7 +163,7 @@ Azure Redis metrics
     - errors
     interval: ["PT1M"]
     timespan: ["PT1M"]
-    aggregation:  
+    aggregation:
     - average
     - total
   static_configs:
@@ -176,10 +177,10 @@ Virtual Gateway metrics
   metrics_path: /probe/metrics/list
   params:
     name: ["my_own_metric_name"]
-    subscription: 
+    subscription:
     - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     filter: ["resourceType eq 'Microsoft.Network/virtualNetworkGateways'"]
-    metric:       
+    metric:
     - AverageBandwidth
     - P2SBandwidth
     - P2SConnectionCount
@@ -219,7 +220,7 @@ Virtual Gateway connection metrics (dimension support)
     - TunnelIngressPacketDropTSMismatch
     interval: ["PT5M"]
     timespan: ["PT5M"]
-    aggregation:  
+    aggregation:
     - average
     - total
     # by connection (dimension support)

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ Azure Redis metrics
   metrics_path: /probe/metrics/list
   params:
     name: ["my_own_metric_name"]
-    subscription:
+    subscription: 
     - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     filter: ["resourceType eq 'Microsoft.Cache/Redis'"]
-    metric:
+    metric:       
     - connectedclients
     - totalcommandsprocessed
     - cachehits
@@ -163,7 +163,7 @@ Azure Redis metrics
     - errors
     interval: ["PT1M"]
     timespan: ["PT1M"]
-    aggregation:
+    aggregation:  
     - average
     - total
   static_configs:
@@ -177,10 +177,10 @@ Virtual Gateway metrics
   metrics_path: /probe/metrics/list
   params:
     name: ["my_own_metric_name"]
-    subscription:
+    subscription: 
     - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     filter: ["resourceType eq 'Microsoft.Network/virtualNetworkGateways'"]
-    metric:
+    metric:       
     - AverageBandwidth
     - P2SBandwidth
     - P2SConnectionCount
@@ -220,7 +220,7 @@ Virtual Gateway connection metrics (dimension support)
     - TunnelIngressPacketDropTSMismatch
     interval: ["PT5M"]
     timespan: ["PT5M"]
-    aggregation:
+    aggregation:  
     - average
     - total
     # by connection (dimension support)

--- a/azure_insights.go
+++ b/azure_insights.go
@@ -34,7 +34,7 @@ func (m *AzureInsightMetrics) MetricsClient(subscriptionId string) *insights.Met
 	m.clientMutex.Lock()
 
 	if _, ok := m.metricsClientCache[subscriptionId]; !ok {
-		client := insights.NewMetricsClient(subscriptionId)
+		client := insights.NewMetricsClientWithBaseURI(AzureAdResourceUrl, subscriptionId)
 		client.Authorizer = AzureAuthorizer
 		m.metricsClientCache[subscriptionId] = &client
 	}
@@ -49,7 +49,7 @@ func (m *AzureInsightMetrics) ResourcesClient(subscriptionId string) *resources.
 	m.clientMutex.Lock()
 
 	if _, ok := m.resourceClientCache[subscriptionId]; !ok {
-		client := resources.NewClient(subscriptionId)
+		client := resources.NewClientWithBaseURI(AzureAdResourceUrl, subscriptionId)
 		client.Authorizer = AzureAuthorizer
 		m.resourceClientCache[subscriptionId] = &client
 	}

--- a/config/opts.go
+++ b/config/opts.go
@@ -16,7 +16,8 @@ type (
 
 		// azure
 		Azure struct {
-			Environment *string `long:"azure-environment"            env:"AZURE_ENVIRONMENT"                description:"Azure environment name" default:"AZUREPUBLICCLOUD"`
+			Environment   *string `long:"azure-environment"            env:"AZURE_ENVIRONMENT"                description:"Azure environment name" default:"AZUREPUBLICCLOUD"`
+			AdResourceUrl *string `long:"azure-ad-resource-url"        env:"AZURE_AD_RESOURCE"                description:"Specifies the AAD resource ID to use. If not set, it defaults to ResourceManagerEndpoint for operations with Azure Resource Manager"`
 		}
 
 		// Prober settings

--- a/main.go
+++ b/main.go
@@ -43,8 +43,9 @@ var (
 	argparser *flags.Parser
 	opts      config.Opts
 
-	AzureEnvironment azure.Environment
-	AzureAuthorizer  autorest.Authorizer
+	AzureEnvironment   azure.Environment
+	AzureAuthorizer    autorest.Authorizer
+	AzureAdResourceUrl string
 
 	prometheusCollectTime    *prometheus.SummaryVec
 	prometheusMetricRequests *prometheus.CounterVec
@@ -130,6 +131,12 @@ func initAzureConnection() {
 	AzureEnvironment, err = azure.EnvironmentFromName(*opts.Azure.Environment)
 	if err != nil {
 		log.Panic(err)
+	}
+
+	if opts.Azure.AdResourceUrl == nil {
+		AzureAdResourceUrl = AzureEnvironment.ResourceManagerEndpoint
+	} else {
+		AzureAdResourceUrl = *opts.Azure.AdResourceUrl
 	}
 
 	// setup azure authorizer


### PR DESCRIPTION
# Reference Issue

https://github.com/webdevops/azure-metrics-exporter/issues/1

# What does it fix?

It allows azure-metrics-exporter work with correct ResourceManagerEndpoint, according Azure Cloud (China, US, Public). 

# Any other comments?

Not sure, that app should get azure-ad-resource-url from parameters.
I thought, that AzureEnvironment.ResourceManagerEndpoint is enough, but if we look at https://github.com/Azure/go-autorest/blob/master/autorest/azure/auth/auth.go#L111 - we may see, that `s.Values[Resource]` use value from `AZURE_AD_RESOURCE` instead of AzureEnvironment.ResourceManagerEndpoint

