### PR TITLE
Support adding tags as labels

### DIFF
--- a/config/opts.go
+++ b/config/opts.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type (
@@ -26,6 +27,7 @@ type (
 
 		Metrics struct {
 			ResourceIdLowercase bool   `long:"metrics.resourceid.lowercase"   env:"METRIC_RESOURCEID_LOWERCASE"       description:"Publish lowercase Azure Resoruce ID in metrics"`
+			TagLabels           string `long:"metrics.tag.labels"             env:"METRIC_TAG_LABELS"                 description:"Comma separated list of Azure tags to include as labels"`
 			Template            string `long:"metrics.template"               env:"METRIC_TEMPLATE"                   description:"Template for metric name"   default:"{name}"`
 			Help                string `long:"metrics.help"                   env:"METRIC_HELP"                       description:"Metric help (with template support)"   default:"Azure monitor insight metric"`
 		}

--- a/metrics/insights.go
+++ b/metrics/insights.go
@@ -201,6 +201,8 @@ func (r *AzureInsightMetricsResult) SendMetricToChannel(channel chan<- Prometheu
 						for _, tag := range r.settings.TagLabels {
 							if val, ok := r.target.Tags[tag]; ok {
 								metricLabels[tag] = *val
+							} else {
+								metricLabels[tag] = ""
 							}
 						}
 

--- a/metrics/insights.go
+++ b/metrics/insights.go
@@ -1,12 +1,13 @@
 package metrics
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/prometheus/client_golang/prometheus"
-	"regexp"
-	"strings"
 )
 
 var (
@@ -20,9 +21,9 @@ type (
 	}
 
 	AzureInsightMetricsResult struct {
-		settings   *RequestMetricSettings
-		Result     *insights.Response
-		ResourceID *string
+		settings *RequestMetricSettings
+		target   *MetricProbeTarget
+		Result   *insights.Response
 	}
 
 	PrometheusMetricResult struct {
@@ -42,6 +43,7 @@ func (p *MetricProber) MetricsClient(subscriptionId string) *insights.MetricsCli
 func (p *MetricProber) FetchMetricsFromTarget(client *insights.MetricsClient, target MetricProbeTarget, metrics, aggregations []string) (AzureInsightMetricsResult, error) {
 	ret := AzureInsightMetricsResult{
 		settings: p.settings,
+		target:   &target,
 	}
 
 	result, err := client.List(
@@ -64,7 +66,6 @@ func (p *MetricProber) FetchMetricsFromTarget(client *insights.MetricsClient, ta
 		}
 
 		ret.Result = &result
-		ret.ResourceID = &target.ResourceId
 	}
 
 	return ret, err
@@ -155,7 +156,7 @@ func (r *AzureInsightMetricsResult) SendMetricToChannel(channel chan<- Prometheu
 							}
 						}
 
-						resourceId := to.String(r.ResourceID)
+						resourceId := to.String(&r.target.ResourceId)
 						if r.settings.LowercaseResourceId {
 							resourceId = strings.ToLower(resourceId)
 						}
@@ -194,6 +195,12 @@ func (r *AzureInsightMetricsResult) SendMetricToChannel(channel chan<- Prometheu
 								labelName := "dimension" + strings.Title(strings.ToLower(dimensionName))
 								labelName = metricLabelNotAllowedChars.ReplaceAllString(labelName, "")
 								metricLabels[labelName] = dimensionValue
+							}
+						}
+
+						for _, tag := range r.settings.TagLabels {
+							if val, ok := r.target.Tags[tag]; ok {
+								metricLabels[tag] = *val
 							}
 						}
 

--- a/metrics/prober.go
+++ b/metrics/prober.go
@@ -2,6 +2,9 @@ package metrics
 
 import (
 	"context"
+	"net/http"
+	"time"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/patrickmn/go-cache"
@@ -10,8 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/webdevops/azure-metrics-exporter/config"
 	"github.com/webdevops/go-prometheus-common/azuretracing"
-	"net/http"
-	"time"
 )
 
 const (
@@ -66,6 +67,7 @@ type (
 		ResourceId   string
 		Metrics      []string
 		Aggregations []string
+		Tags         map[string]*string
 	}
 )
 

--- a/metrics/settings.go
+++ b/metrics/settings.go
@@ -2,13 +2,14 @@ package metrics
 
 import (
 	"fmt"
-	iso8601 "github.com/ChannelMeter/iso8601duration"
-	log "github.com/sirupsen/logrus"
-	"github.com/webdevops/azure-metrics-exporter/config"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	iso8601 "github.com/ChannelMeter/iso8601duration"
+	log "github.com/sirupsen/logrus"
+	"github.com/webdevops/azure-metrics-exporter/config"
 )
 
 const (
@@ -38,6 +39,7 @@ type (
 		HelpTemplate   string
 
 		LowercaseResourceId bool
+		TagLabels           []string
 
 		// cache
 		Cache *time.Duration
@@ -69,6 +71,7 @@ func NewRequestMetricSettings(r *http.Request, opts config.Opts) (RequestMetricS
 	params := r.URL.Query()
 
 	ret.LowercaseResourceId = opts.Metrics.ResourceIdLowercase
+	ret.TagLabels = strings.Split(opts.Metrics.TagLabels, ",")
 
 	// param name
 	ret.Name = paramsGetWithDefault(params, "name", PrometheusMetricNameDefault)


### PR DESCRIPTION
Add new command arg `--metrics.tag.labels=` to add certain Azure tags as labels.

Prefer to have the labels on metric instead of using promql join as some essential tags are used to identify which application resource belongs to. Additionally it also supports label specific access control with Grafana Enterprise much better.

Example usage: 

```bash
.\azure-metrics-exporter.exe --development.webui --metrics.resourceid.lowercase --metrics.tag.labels=env,app
```