### PR TITLE
Support setting timestamp on metric

### DIFF
--- a/config/opts.go
+++ b/config/opts.go
@@ -26,6 +26,7 @@ type (
 
 		Metrics struct {
 			ResourceIdLowercase bool   `long:"metrics.resourceid.lowercase"   env:"METRIC_RESOURCEID_LOWERCASE"       description:"Publish lowercase Azure Resoruce ID in metrics"`
+			SetTimestamp        bool   `long:"metrics.set-timestamp"          env:"METRIC_SET_TIMESTAMP"              description:"Set timestamp on scraped metrics"`
 			Template            string `long:"metrics.template"               env:"METRIC_TEMPLATE"                   description:"Template for metric name"   default:"{name}"`
 			Help                string `long:"metrics.help"                   env:"METRIC_HELP"                       description:"Metric help (with template support)"   default:"Azure monitor insight metric"`
 		}

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metricListCollectorDetails struct {
+	gauge prometheus.Gauge
+	desc  *prometheus.Desc
+	ts    time.Time
+}
+
+type metricListCollector struct {
+	details []*metricListCollectorDetails
+}
+
+func NewMetricListCollector(list *MetricList) *metricListCollector {
+	collector := &metricListCollector{
+		details: []*metricListCollectorDetails{},
+	}
+
+	if list == nil {
+		return collector
+	}
+
+	// create prometheus metrics and set rows
+	for _, metricName := range list.GetMetricNames() {
+		gaugeVec := prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: metricName,
+				Help: list.GetMetricHelp(metricName),
+			},
+			list.GetMetricLabelNames(metricName),
+		)
+
+		latest := list.GetLatestMetric(metricName)
+
+		gauge := gaugeVec.With(latest.Labels)
+		gauge.Set(latest.Value)
+
+		desc := prometheus.NewDesc(metricName, list.GetMetricHelp(metricName), []string{}, latest.Labels)
+
+		details := &metricListCollectorDetails{
+			gauge,
+			desc,
+			latest.Timestamp,
+		}
+
+		collector.details = append(collector.details, details)
+	}
+
+	return collector
+}
+
+func (c *metricListCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, detail := range c.details {
+		ch <- detail.desc
+	}
+}
+
+func (c *metricListCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, detail := range c.details {
+		s := prometheus.NewMetricWithTimestamp(detail.ts, detail.gauge)
+		ch <- s
+	}
+}

--- a/metrics/insights.go
+++ b/metrics/insights.go
@@ -1,12 +1,14 @@
 package metrics
 
 import (
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/prometheus/client_golang/prometheus"
-	"regexp"
-	"strings"
 )
 
 var (
@@ -26,10 +28,11 @@ type (
 	}
 
 	PrometheusMetricResult struct {
-		Name   string
-		Labels prometheus.Labels
-		Value  float64
-		Help   string
+		Name      string
+		Labels    prometheus.Labels
+		Value     float64
+		Timestamp time.Time
+		Help      string
 	}
 )
 
@@ -70,7 +73,7 @@ func (p *MetricProber) FetchMetricsFromTarget(client *insights.MetricsClient, ta
 	return ret, err
 }
 
-func (r *AzureInsightMetricsResult) buildMetric(labels prometheus.Labels, value float64) (metric PrometheusMetricResult) {
+func (r *AzureInsightMetricsResult) buildMetric(labels prometheus.Labels, value float64, timestamp time.Time) (metric PrometheusMetricResult) {
 	// copy map to ensure we don't keep references
 	metricLabels := prometheus.Labels{}
 	for labelName, labelValue := range labels {
@@ -78,9 +81,10 @@ func (r *AzureInsightMetricsResult) buildMetric(labels prometheus.Labels, value 
 	}
 
 	metric = PrometheusMetricResult{
-		Name:   r.settings.MetricTemplate,
-		Labels: metricLabels,
-		Value:  value,
+		Name:      r.settings.MetricTemplate,
+		Labels:    metricLabels,
+		Value:     value,
+		Timestamp: timestamp,
 	}
 
 	// fallback if template is empty (should not be)
@@ -140,8 +144,8 @@ func (r *AzureInsightMetricsResult) buildMetric(labels prometheus.Labels, value 
 func (r *AzureInsightMetricsResult) SendMetricToChannel(channel chan<- PrometheusMetricResult) {
 	if r.Result.Value != nil {
 		// DEBUGGING
-		//data, _ := json.Marshal(r.Result)
-		//fmt.Println(string(data))
+		// data, _ := json.Marshal(r.Result)
+		// fmt.Println(string(data))
 
 		for _, metric := range *r.Result.Value {
 			if metric.Timeseries != nil {
@@ -203,6 +207,7 @@ func (r *AzureInsightMetricsResult) SendMetricToChannel(channel chan<- Prometheu
 								channel <- r.buildMetric(
 									metricLabels,
 									*timeseriesData.Total,
+									timeseriesData.TimeStamp.Time,
 								)
 							}
 
@@ -211,6 +216,7 @@ func (r *AzureInsightMetricsResult) SendMetricToChannel(channel chan<- Prometheu
 								channel <- r.buildMetric(
 									metricLabels,
 									*timeseriesData.Minimum,
+									timeseriesData.TimeStamp.Time,
 								)
 							}
 
@@ -219,6 +225,7 @@ func (r *AzureInsightMetricsResult) SendMetricToChannel(channel chan<- Prometheu
 								channel <- r.buildMetric(
 									metricLabels,
 									*timeseriesData.Maximum,
+									timeseriesData.TimeStamp.Time,
 								)
 							}
 
@@ -227,6 +234,7 @@ func (r *AzureInsightMetricsResult) SendMetricToChannel(channel chan<- Prometheu
 								channel <- r.buildMetric(
 									metricLabels,
 									*timeseriesData.Average,
+									timeseriesData.TimeStamp.Time,
 								)
 							}
 
@@ -235,6 +243,7 @@ func (r *AzureInsightMetricsResult) SendMetricToChannel(channel chan<- Prometheu
 								channel <- r.buildMetric(
 									metricLabels,
 									*timeseriesData.Count,
+									timeseriesData.TimeStamp.Time,
 								)
 							}
 						}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,6 +1,10 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 const (
 	MetricHelpDefault = "Azure monitor insight metric"
@@ -13,8 +17,9 @@ type (
 	}
 
 	MetricRow struct {
-		Labels prometheus.Labels
-		Value  float64
+		Labels    prometheus.Labels
+		Value     float64
+		Timestamp time.Time
 	}
 )
 
@@ -53,6 +58,18 @@ func (l *MetricList) GetMetricHelp(name string) string {
 
 func (l *MetricList) GetMetricList(name string) []MetricRow {
 	return l.List[name]
+}
+
+func (l *MetricList) GetLatestMetric(name string) *MetricRow {
+	var latest *MetricRow
+
+	for _, row := range l.List[name] {
+		if latest == nil || row.Timestamp.After(latest.Timestamp) {
+			latest = &row
+		}
+	}
+
+	return latest
 }
 
 func (l *MetricList) GetMetricLabelNames(name string) []string {

--- a/metrics/prober.go
+++ b/metrics/prober.go
@@ -211,8 +211,9 @@ func (p *MetricProber) collectMetricsFromTargets() {
 
 	for result := range metricsChannel {
 		metric := MetricRow{
-			Labels: result.Labels,
-			Value:  result.Value,
+			Labels:    result.Labels,
+			Value:     result.Value,
+			Timestamp: result.Timestamp,
 		}
 		p.metricList.Add(result.Name, metric)
 		p.metricList.SetMetricHelp(result.Name, result.Help)
@@ -220,6 +221,11 @@ func (p *MetricProber) collectMetricsFromTargets() {
 }
 
 func (p *MetricProber) publishMetricList() {
+	if p.Conf.Metrics.SetTimestamp {
+		p.prometheus.registry.MustRegister(NewMetricListCollector(p.metricList))
+		return
+	}
+
 	if p.metricList == nil {
 		return
 	}


### PR DESCRIPTION
As noted in one of the issues the actual timestamp of metrics received from Azure API is slightly behind scrape time. This change has an opt in feature to set the timestamp on metrics so it is the correct timestamp.

At the moment this does not deal with caching, so only works if caching is disabled. It cannot guarantee behavior of prometheus server if it will reject old samples etc. Left the old code intact so this is an opt in feature.

Example usage:
```bash
.\azure-metrics-exporter.exe --development.webui --metrics.resourceid.lowercase --metrics.set-timestamp
```