### PR TITLE
Filter or resourceType not required for single resource probe

### DIFF
--- a/metrics/settings.go
+++ b/metrics/settings.go
@@ -52,7 +52,9 @@ func NewRequestMetricSettingsForAzureResourceApi(r *http.Request, opts config.Op
 		return settings, err
 	}
 
-	if settings.ResourceType != "" && settings.Filter != "" {
+	if r.URL.Path == "/probe/metrics/resource" {
+		return settings, nil
+	} else if settings.ResourceType != "" && settings.Filter != "" {
 		return settings, fmt.Errorf("parameter \"resourceType\" and \"filter\" are mutually exclusive")
 	} else if settings.ResourceType != "" {
 		settings.Filter = fmt.Sprintf(


### PR DESCRIPTION
Addresses #27 
```
ERRO[0003] parameter "resourceType" or "filter" is missing  paramAggregation="[average,total,count]" paramHelp="[Azure metric {metric} for {aggregation}]" paramInterval="[PT1H]" paramMetric="[backup_storage_used]" paramMetricTop="[10]" paramName="[azure_metric]" paramSubscription="[xxxxxxxxxxxxxxxxxxxxxxxxxxxxx]" paramTarget="[/subscriptions/xxxxxxxxxxxxxxxxx/resourceGroups/xxxxxxxxxxxx/providers/resource/name]" paramTemplate="[{name}_{metric}_{aggregation}_{unit}]" paramTimespan="[PT1H]" requestPath=/probe/metrics/resource
```