### PR TITLE
Cleanup and remove unused code

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,12 +312,13 @@ azurerm_ratelimit{scope="subscription",subscriptionID="...",type="read"} 11999
 
 ## HTTP Endpoints
 
-| Endpoint                       | Description                                                                         |
-|--------------------------------|-------------------------------------------------------------------------------------|
-| `/metrics`                     | Default prometheus golang metrics                                                   |
-| `/probe/metrics/resource`      | Probe metrics for one resource (see `azurerm_resource_metric`)                      |
-| `/probe/metrics/list`          | Probe metrics for list of resources (see `azurerm_resource_metric`)                 |
-| `/probe/metrics/scrape`        | Probe metrics for list of resources and config on resource by tag name (see `azurerm_resource_metric`) |
+| Endpoint                      | Description                                                                                            |
+|-------------------------------|--------------------------------------------------------------------------------------------------------|
+| `/metrics`                    | Default prometheus golang metrics                                                                      |
+| `/probe/metrics/resource`     | Probe metrics for one resource (see `azurerm_resource_metric`)                                         |
+| `/probe/metrics/list`         | Probe metrics for list of resources (see `azurerm_resource_metric`)                                    |
+| `/probe/metrics/scrape`       | Probe metrics for list of resources and config on resource by tag name (see `azurerm_resource_metric`) |
+| `/probe/metrics/resourcegraph`        | Probe metrics for list of resources based on a kusto query and the resource graph API                  |
 
 ### /probe/metrics/resource parameters
 

--- a/README.md
+++ b/README.md
@@ -326,10 +326,9 @@ azurerm_ratelimit{scope="subscription",subscriptionID="...",type="read"} 11999
 |------------------------|---------------------------|----------|----------|----------------------------------------------------------------------|
 | `subscription`         |                           | **yes**  | **yes**  | Azure Subscription ID                                                |
 | `target`               |                           | **yes**  | **yes**  | Azure Resource URI                                                   |
-| `resourceSubPath`      |                           | no       | no       | Additional resource path which will be appended to Resource ID       |
 | `timespan`             | `PT1M`                    | no       | no       | Metric timespan                                                      |
 | `interval`             |                           | no       | no       | Metric timespan                                                      |
-| `metricNamespace`      |                           | no       | **yes**  | Metric namespace (might need also `resourceSubPath`)                 |
+| `metricNamespace`      |                           | no       | **yes**  | Metric namespace                  |
 | `metric`               |                           | no       | **yes**  | Metric name                                                          |
 | `aggregation`          |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, `count`, multiple possible separated with `,`) |
 | `name`                 | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                               |
@@ -350,10 +349,9 @@ HINT: service discovery information is cached for duration set by `$AZURE_SERVIC
 |----------------------------|---------------------------|----------|----------|----------------------------------------------------------------------|
 | `subscription`             |                           | **yes**  | **yes**  | Azure Subscription ID (or multiple separate by comma)                |
 | `resourceType` or `filter` |                           | **yes**  | no       | Azure Resource type or filter query (https://docs.microsoft.com/en-us/rest/api/resources/resources/list) |
-| `resourceSubPath`          |                           | no       | no       | Additional resource path which will be appended to Resource ID       |
 | `timespan`                 | `PT1M`                    | no       | no       | Metric timespan                                                      |
 | `interval`                 |                           | no       | no       | Metric timespan                                                      |
-| `metricNamespace`          |                           | no       | **yes**  | Metric namespace (might need also `resourceSubPath`)                 |
+| `metricNamespace`          |                           | no       | **yes**  | Metric namespace                  |
 | `metric`                   |                           | no       | **yes**  | Metric name                                                          |
 | `aggregation`              |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, `count`, multiple possible separated with `,`) |
 | `name`                     | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                               |
@@ -374,12 +372,11 @@ HINT: service discovery information is cached for duration set by `$AZURE_SERVIC
 |----------------------------|---------------------------|----------|----------|----------------------------------------------------------------------|
 | `subscription`             |                           | **yes**  | **yes**  | Azure Subscription ID  (or multiple separate by comma)               |
 | `resourceType` or `filter` |                           | **yes**  | no       | Azure Resource type or filter query (https://docs.microsoft.com/en-us/rest/api/resources/resources/list) |
-| `resourceSubPath`          |                           | no       | no       | Additional resource path which will be appended to Resource ID       |
 | `metricTagName`            |                           | **yes**  | no       | Resource tag name for getting "metrics" list                         |
 | `aggregationTagName`       |                           | **yes**  | no       | Resource tag name for getting "aggregations" list                    |
 | `timespan`                 | `PT1M`                    | no       | no       | Metric timespan                                                      |
 | `interval`                 |                           | no       | no       | Metric timespan                                                      |
-| `metricNamespace`          |                           | no       | **yes**  | Metric namespace (might need also `resourceSubPath`)                 |
+| `metricNamespace`          |                           | no       | **yes**  | Metric namespace                  |
 | `metric`                   |                           | no       | **yes**  | Metric name                                                          |
 | `aggregation`              |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, multiple possible separated with `,`)  |
 | `name`                     | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                               |
@@ -404,10 +401,9 @@ HINT: service discovery information is cached for duration set by `$AZURE_SERVIC
 | `subscription`             |                           | **yes**  | **yes**  | Azure Subscription ID (or multiple separate by comma)                |
 | `resourceType`             |                           | **yes**  | no       | Azure Resource type                                                  |
 | `filter`                   |                           | no       | no       | Additional Kusto query part (eg. `where id contains "/xzy/"`)        |
-| `resourceSubPath`          |                           | no       | no       | Additional resource path which will be appended to Resource ID       |
 | `timespan`                 | `PT1M`                    | no       | no       | Metric timespan                                                      |
 | `interval`                 |                           | no       | no       | Metric timespan                                                      |
-| `metricNamespace`          |                           | no       | **yes**  | Metric namespace (might need also `resourceSubPath`)                 |
+| `metricNamespace`          |                           | no       | **yes**  | Metric namespace                  |
 | `metric`                   |                           | no       | **yes**  | Metric name                                                          |
 | `aggregation`              |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, `count`, multiple possible separated with `,`) |
 | `name`                     | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                               |
@@ -620,7 +616,6 @@ Virtual Gateway connection metrics (dimension support)
     subscription:
     - xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     resourceType: ["Microsoft.Storage/storageAccounts"]
-    resourceSubPath: ["blobServices/default"] # will be appened to resource ID
     metricNamespace: ["Microsoft.Storage/storageAccounts/blobServices"]
     metric:
     - BlobCapacity

--- a/README.md
+++ b/README.md
@@ -159,15 +159,16 @@ Help recommendation: `Azure metrics for {metric} with aggregation {aggregation} 
 
 Following templates are available:
 
-| Template         |  Description                                                                                      |
-|------------------|---------------------------------------------------------------------------------------------------|
-| `{name}`         | Name of template specified by request parameter `name`                                            |
-| `{metric}`       | Name of Azure monitor metric                                                                      |
-| `{dimension}`    | Dimension value of Azure monitor metric (if dimension is used)                                    |
-| `{unit}`         | Unit name of Azure monitor metric (eg `count`, `percent`, ...)                                    |
-| `{aggregation}`  | Aggregation of Azure monitor metric (eg `total`, `average`)                                       |
-| `{interval}`     | Interval of requested Azure monitor metric                                                        |
-| `{timespan}`     | Timespan of requested Azure monitor metric                                                        |
+| Template        | Description                                                                               |
+|-----------------|-------------------------------------------------------------------------------------------|
+| `{name}`        | Name of template specified by request parameter `name`                                    |
+| `{type}`        | The ResourceType or MetricNamespace specified in the request (not applicable to all APIs) |
+| `{metric}`      | Name of Azure monitor metric                                                              |
+| `{dimension}`   | Dimension value of Azure monitor metric (if dimension is used)                            |
+| `{unit}`        | Unit name of Azure monitor metric (eg `count`, `percent`, ...)                            |
+| `{aggregation}` | Aggregation of Azure monitor metric (eg `total`, `average`)                               |
+| `{interval}`    | Interval of requested Azure monitor metric                                                |
+| `{timespan}`    | Timespan of requested Azure monitor metric                                                |
 
 #### default template
 

--- a/metrics/insights.go
+++ b/metrics/insights.go
@@ -102,7 +102,7 @@ func (r *AzureInsightMetricsResult) buildMetric(labels prometheus.Labels, value 
 	}
 
 	// fallback if template is empty (should not be)
-	if r.settings.Name == "" {
+	if r.settings.MetricTemplate == "" {
 		metric.Name = r.settings.Name
 	}
 

--- a/metrics/prober.go
+++ b/metrics/prober.go
@@ -68,10 +68,9 @@ type (
 	}
 )
 
-func NewMetricProber(ctx context.Context, logger *log.Entry, w http.ResponseWriter, r *http.Request, settings *RequestMetricSettings, conf config.Opts) *MetricProber {
+func NewMetricProber(ctx context.Context, logger *log.Entry, w http.ResponseWriter, settings *RequestMetricSettings, conf config.Opts) *MetricProber {
 	prober := MetricProber{}
 	prober.ctx = ctx
-	prober.request = r
 	prober.response = w
 	prober.logger = logger
 	prober.settings = settings

--- a/metrics/settings.go
+++ b/metrics/settings.go
@@ -21,7 +21,6 @@ type (
 	RequestMetricSettings struct {
 		Name            string
 		Subscriptions   []string
-		ResourceSubPath string
 		ResourceType    string
 		Filter          string
 		Timespan        string
@@ -29,7 +28,6 @@ type (
 		Metrics         []string
 		MetricNamespace string
 		Aggregations    []string
-		Target          []string
 
 		// needed for dimension support
 		MetricTop     *int32
@@ -87,13 +85,6 @@ func NewRequestMetricSettings(r *http.Request, opts config.Opts) (RequestMetricS
 		return ret, err
 	}
 
-	// param metricNamespace
-	ret.ResourceSubPath = paramsGetWithDefault(params, "resourceSubPath", "")
-	ret.ResourceSubPath = fmt.Sprintf(
-		"/%s",
-		strings.TrimLeft(ret.ResourceSubPath, "/"),
-	)
-
 	// param filter
 	ret.ResourceType = paramsGetWithDefault(params, "resourceType", "")
 	ret.Filter = paramsGetWithDefault(params, "filter", "")
@@ -119,13 +110,6 @@ func NewRequestMetricSettings(r *http.Request, opts config.Opts) (RequestMetricS
 	// param aggregation
 	if val, err := paramsGetList(params, "aggregation"); err == nil {
 		ret.Aggregations = val
-	} else {
-		return ret, err
-	}
-
-	// param target
-	if val, err := paramsGetList(params, "target"); err == nil {
-		ret.Target = val
 	} else {
 		return ret, err
 	}

--- a/probe_metrics_list.go
+++ b/probe_metrics_list.go
@@ -41,7 +41,7 @@ func probeMetricsListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prober := metrics.NewMetricProber(ctx, contextLogger, w, r, &settings, opts)
+	prober := metrics.NewMetricProber(ctx, contextLogger, w, &settings, opts)
 	prober.SetUserAgent(UserAgent + gitTag)
 	prober.SetAzureClient(AzureClient)
 	prober.SetPrometheusRegistry(registry)

--- a/probe_metrics_resource.go
+++ b/probe_metrics_resource.go
@@ -41,7 +41,7 @@ func probeMetricsResourceHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prober := metrics.NewMetricProber(ctx, contextLogger, w, r, &settings, opts)
+	prober := metrics.NewMetricProber(ctx, contextLogger, w, &settings, opts)
 	prober.SetUserAgent(UserAgent + gitTag)
 	prober.SetAzureClient(AzureClient)
 	prober.SetPrometheusRegistry(registry)

--- a/probe_metrics_resourcegraph.go
+++ b/probe_metrics_resourcegraph.go
@@ -48,7 +48,7 @@ func probeMetricsResourceGraphHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prober := metrics.NewMetricProber(ctx, contextLogger, w, r, &settings, opts)
+	prober := metrics.NewMetricProber(ctx, contextLogger, w, &settings, opts)
 	prober.SetUserAgent(UserAgent + gitTag)
 	prober.SetAzureClient(AzureClient)
 	prober.SetPrometheusRegistry(registry)

--- a/probe_metrics_scrape.go
+++ b/probe_metrics_scrape.go
@@ -53,7 +53,7 @@ func probeMetricsScrapeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prober := metrics.NewMetricProber(ctx, contextLogger, w, r, &settings, opts)
+	prober := metrics.NewMetricProber(ctx, contextLogger, w, &settings, opts)
 	prober.SetUserAgent(UserAgent + gitTag)
 	prober.SetAzureClient(AzureClient)
 	prober.SetPrometheusRegistry(registry)

--- a/templates/query.html
+++ b/templates/query.html
@@ -230,14 +230,6 @@
             </div>
 
             <div class="mb-3 row">
-                <label for="resourceSubPath" class="col-sm-2 col-form-label">resourceSubPath</label>
-                <div class="col-sm-10">
-                    <input type="text" class="form-control" id="resourceSubPath">
-                    <div class="form-text">Additional path for namespaced metrics (eg. Azure StorageAccount sub metrics)</div>
-                </div>
-            </div>
-
-            <div class="mb-3 row">
                 <label for="metricNamespace" class="col-sm-2 col-form-label">metricNamespace</label>
                 <div class="col-sm-10">
                     <input type="text" class="form-control" id="metricNamespace">


### PR DESCRIPTION
👋 first I just wanted to say thank you for maintaining this exporter! I stumbled across it and noticed a few things small things which I fixed up in this PR. I'm happy to break it down in to smaller PR's but figured I would start with 1 since it's rather small. Highlights include,

* Eliminate the need for specifying a `ResourceSubPath` manually AFAIK this param is only used in conjunction with `microsoft.storage/storageaccounts/` so `insights.go` handles it now. Specific commit: https://github.com/webdevops/azure-metrics-exporter/commit/939edb5aa7c00f47571b5bf88e7a11ebc3494d63
* Logic fix which could cause empty metric names if `Name` is empty but `MetricTemplate` is not empty. Specific commit: https://github.com/webdevops/azure-metrics-exporter/commit/8020c3a22085d47d5593f2c05f092394996ce0d1
* Removing some unused params from APIs/internal code/README
* Add support for `{type}` as a template value. Specific commit: https://github.com/webdevops/azure-metrics-exporter/pull/41/commits/16e25d5c8d3bc9a0e684ae0ac2e8d202fc6e3309
  * Seems like `name` is intended to allow a user to differentiate metrics for different Resource Types
  * Allowing `type` in the template can help a user link the data back to the source system since the metric names are more directly tied to the azure definition