### PR TITLE
Add support for metricNamespace on cross-resource queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,22 +301,23 @@ azurerm_ratelimit{scope="subscription",subscriptionID="...",type="read"} 11999
 
 one metric request per subscription and region
 
-| GET parameter   | Default                   | Required | Multiple | Description                                                                                                                                          |
-|-----------------|---------------------------|----------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `subscription`  |                           | **yes**  | **yes**  | Azure Subscription ID                                                                                                                                |
-| `region`        |                           | **yes**  | **yes**  | Azure Regions (eg. `westeurope`, `northeurope`)                                                                                                      |
-| `resourceType`  |                           | **yes**  | no       | Azure Resource type                                                                                                                                  |
-| `timespan`      | `PT1M`                    | no       | no       | Metric timespan                                                                                                                                      |
-| `interval`      |                           | no       | no       | Metric timespan                                                                                                                                      |
-| `metric`        |                           | no       | **yes**  | Metric name                                                                                                                                          |
-| `aggregation`   |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, `count`, multiple possible separated with `,`)                                         |
-| `name`          | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                                                                                                               |
-| `metricFilter`  |                           | no       | no       | Prometheus metric filter (dimension support; supports only 2 filters in subscription query mode as the first filter is used to split by resource id) |
-| `metricTop`     |                           | no       | no       | Prometheus metric dimension count (dimension support)                                                                                                |
-| `metricOrderBy` |                           | no       | no       | Prometheus metric order by (dimension support)                                                                                                       |
-| `cache`         | (same as timespan)        | no       | no       | Use of internal metrics caching                                                                                                                      |
-| `template`      | set to `$METRIC_TEMPLATE` | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                                                                    |
-| `help`          | set to `$METRIC_HELP`     | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                                                                    |
+| GET parameter     | Default                   | Required | Multiple | Description                                                                                                                                          |
+|-------------------|---------------------------|----------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `subscription`    |                           | **yes**  | **yes**  | Azure Subscription ID                                                                                                                                |
+| `region`          |                           | **yes**  | **yes**  | Azure Regions (eg. `westeurope`, `northeurope`)                                                                                                      |
+| `resourceType`    |                           | **yes**  | no       | Azure Resource type                                                                                                                                  |
+| `timespan`        | `PT1M`                    | no       | no       | Metric timespan                                                                                                                                      |
+| `interval`        |                           | no       | no       | Metric timespan                                                                                                                                      |
+| `metricNamespace` |                           | no       | no       | Metric namespace                                                                                                                                     |
+| `metric`          |                           | no       | **yes**  | Metric name                                                                                                                                          |
+| `aggregation`     |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, `count`, multiple possible separated with `,`)                                         |
+| `name`            | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                                                                                                               |
+| `metricFilter`    |                           | no       | no       | Prometheus metric filter (dimension support; supports only 2 filters in subscription query mode as the first filter is used to split by resource id) |
+| `metricTop`       |                           | no       | no       | Prometheus metric dimension count (dimension support)                                                                                                |
+| `metricOrderBy`   |                           | no       | no       | Prometheus metric order by (dimension support)                                                                                                       |
+| `cache`           | (same as timespan)        | no       | no       | Use of internal metrics caching                                                                                                                      |
+| `template`        | set to `$METRIC_TEMPLATE` | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                                                                    |
+| `help`            | set to `$METRIC_HELP`     | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                                                                    |
 
 *Hint: Multiple values can be specified multiple times or with a comma in a single value.*
 

--- a/metrics/prober.go
+++ b/metrics/prober.go
@@ -223,6 +223,10 @@ func (p *MetricProber) collectMetricsFromSubscriptions() {
 						opts.Orderby = to.StringPtr(p.settings.MetricOrderBy)
 					}
 
+					if len(p.settings.MetricNamespace) >= 1 {
+						opts.Metricnamespace = to.StringPtr(p.settings.MetricNamespace)
+					}
+
 					response, err := client.ListAtSubscriptionScope(p.ctx, region, &opts)
 					if err != nil {
 						// FIXME: find a better way to report errors

--- a/templates/query.html
+++ b/templates/query.html
@@ -238,7 +238,7 @@
                 </div>
             </div>
 
-            <div class="mb-3 row" query-endpoint-exclude="/probe/metrics">
+            <div class="mb-3 row">
                 <label for="metricNamespace" class="col-sm-2 col-form-label">metricNamespace</label>
                 <div class="col-sm-10">
                     <input type="text" class="form-control" id="metricNamespace">


### PR DESCRIPTION
For requests metrics from custom namespaces, e.g.: insights.virtualmachine, I still need to define the metricNamespace for `/probe/metrics`.