### PR TITLE
allow resourceType and filter to both be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,23 +352,23 @@ metrics are requested per resource in chunks of 20 metric names (35 metric names
 
 HINT: service discovery information is cached for duration set by `$AZURE_SERVICEDISCOVERY_CACHE` (set to `0` to disable)
 
-| GET parameter              | Default                   | Required | Multiple | Description                                                                                                  |
-|----------------------------|---------------------------|----------|----------|--------------------------------------------------------------------------------------------------------------|
-| `subscription`             |                           | **yes**  | **yes**  | Azure Subscription ID (or multiple separate by comma)                                                        |
-| `resourceType` or `filter` |                           | **yes**  | no       | Azure Resource type or filter query (https://docs.microsoft.com/en-us/rest/api/resources/resources/list)     |
-| `timespan`                 | `PT1M`                    | no       | no       | Metric timespan                                                                                              |
-| `interval`                 |                           | no       | no       | Metric timespan                                                                                              |
-| `metricNamespace`          |                           | no       | **yes**  | Metric namespace                                                                                             |
-| `metric`                   |                           | no       | **yes**  | Metric name                                                                                                  |
-| `aggregation`              |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, `count`, multiple possible separated with `,`) |
-| `name`                     | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                                                                       |
-| `metricFilter`             |                           | no       | no       | Prometheus metric filter (dimension support)                                                                 |
-| `metricTop`                |                           | no       | no       | Prometheus metric dimension count (dimension support)                                                        |
-| `metricOrderBy`            |                           | no       | no       | Prometheus metric order by (dimension support)                                                               |
-| `validateDimensions`       | `true`                    | no       | no       | When set to false, invalid filter parameter values will be ignored.                                          |
-| `cache`                    | (same as timespan)        | no       | no       | Use of internal metrics caching                                                                              |
-| `template`                 | set to `$METRIC_TEMPLATE` | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                            |
-| `help`                     | set to `$METRIC_HELP`     | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                            |
+| GET parameter              | Default                   | Required | Multiple | Description                                                                                                                                                                     |
+|----------------------------|---------------------------|----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `subscription`             |                           | **yes**  | **yes**  | Azure Subscription ID (or multiple separate by comma)                                                                                                                           |
+| `resourceType` or `filter` |                           | **yes**  | no       | Azure Resource type or filter query (https://docs.microsoft.com/en-us/rest/api/resources/resources/list). When both are specified, the `resourceType` filtering occurs locally. |
+| `timespan`                 | `PT1M`                    | no       | no       | Metric timespan                                                                                                                                                                 |
+| `interval`                 |                           | no       | no       | Metric timespan                                                                                                                                                                 |
+| `metricNamespace`          |                           | no       | **yes**  | Metric namespace                                                                                                                                                                |
+| `metric`                   |                           | no       | **yes**  | Metric name                                                                                                                                                                     |
+| `aggregation`              |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, `count`, multiple possible separated with `,`)                                                                    |
+| `name`                     | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                                                                                                                                          |
+| `metricFilter`             |                           | no       | no       | Prometheus metric filter (dimension support)                                                                                                                                    |
+| `metricTop`                |                           | no       | no       | Prometheus metric dimension count (dimension support)                                                                                                                           |
+| `metricOrderBy`            |                           | no       | no       | Prometheus metric order by (dimension support)                                                                                                                                  |
+| `validateDimensions`       | `true`                    | no       | no       | When set to false, invalid filter parameter values will be ignored.                                                                                                             |
+| `cache`                    | (same as timespan)        | no       | no       | Use of internal metrics caching                                                                                                                                                 |
+| `template`                 | set to `$METRIC_TEMPLATE` | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                                                                                               |
+| `help`                     | set to `$METRIC_HELP`     | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                                                                                               |
 
 *Hint: Multiple values can be specified multiple times or with a comma in a single value.*
 
@@ -376,25 +376,25 @@ HINT: service discovery information is cached for duration set by `$AZURE_SERVIC
 
 HINT: service discovery information is cached for duration set by `$AZURE_SERVICEDISCOVERY_CACHE` (set to `0` to disable)
 
-| GET parameter              | Default                   | Required | Multiple | Description                                                                                              |
-|----------------------------|---------------------------|----------|----------|----------------------------------------------------------------------------------------------------------|
-| `subscription`             |                           | **yes**  | **yes**  | Azure Subscription ID  (or multiple separate by comma)                                                   |
-| `resourceType` or `filter` |                           | **yes**  | no       | Azure Resource type or filter query (https://docs.microsoft.com/en-us/rest/api/resources/resources/list) |
-| `metricTagName`            |                           | **yes**  | no       | Resource tag name for getting "metrics" list                                                             |
-| `aggregationTagName`       |                           | **yes**  | no       | Resource tag name for getting "aggregations" list                                                        |
-| `timespan`                 | `PT1M`                    | no       | no       | Metric timespan                                                                                          |
-| `interval`                 |                           | no       | no       | Metric timespan                                                                                          |
-| `metricNamespace`          |                           | no       | **yes**  | Metric namespace                                                                                         |
-| `metric`                   |                           | no       | **yes**  | Metric name                                                                                              |
-| `aggregation`              |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, multiple possible separated with `,`)      |
-| `name`                     | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                                                                   |
-| `metricFilter`             |                           | no       | no       | Prometheus metric filter (dimension support)                                                             |
-| `metricTop`                |                           | no       | no       | Prometheus metric dimension count (integer, dimension support)                                           |
-| `metricOrderBy`            |                           | no       | no       | Prometheus metric order by (dimension support)                                                           |
-| `validateDimensions`       | `true`                    | no       | no       | When set to false, invalid filter parameter values will be ignored.                                      |
-| `cache`                    | (same as timespan)        | no       | no       | Use of internal metrics caching                                                                          |
-| `template`                 | set to `$METRIC_TEMPLATE` | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                        |
-| `help`                     | set to `$METRIC_HELP`     | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                        |
+| GET parameter              | Default                   | Required | Multiple | Description                                                                                                                                                                     |
+|----------------------------|---------------------------|----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `subscription`             |                           | **yes**  | **yes**  | Azure Subscription ID  (or multiple separate by comma)                                                                                                                          |
+| `resourceType` or `filter` |                           | **yes**  | no       | Azure Resource type or filter query (https://docs.microsoft.com/en-us/rest/api/resources/resources/list). When both are specified, the `resourceType` filtering occurs locally. |
+| `metricTagName`            |                           | **yes**  | no       | Resource tag name for getting "metrics" list                                                                                                                                    |
+| `aggregationTagName`       |                           | **yes**  | no       | Resource tag name for getting "aggregations" list                                                                                                                               |
+| `timespan`                 | `PT1M`                    | no       | no       | Metric timespan                                                                                                                                                                 |
+| `interval`                 |                           | no       | no       | Metric timespan                                                                                                                                                                 |
+| `metricNamespace`          |                           | no       | **yes**  | Metric namespace                                                                                                                                                                |
+| `metric`                   |                           | no       | **yes**  | Metric name                                                                                                                                                                     |
+| `aggregation`              |                           | no       | **yes**  | Metric aggregation (`minimum`, `maximum`, `average`, `total`, multiple possible separated with `,`)                                                                             |
+| `name`                     | `azurerm_resource_metric` | no       | no       | Prometheus metric name                                                                                                                                                          |
+| `metricFilter`             |                           | no       | no       | Prometheus metric filter (dimension support)                                                                                                                                    |
+| `metricTop`                |                           | no       | no       | Prometheus metric dimension count (integer, dimension support)                                                                                                                  |
+| `metricOrderBy`            |                           | no       | no       | Prometheus metric order by (dimension support)                                                                                                                                  |
+| `validateDimensions`       | `true`                    | no       | no       | When set to false, invalid filter parameter values will be ignored.                                                                                                             |
+| `cache`                    | (same as timespan)        | no       | no       | Use of internal metrics caching                                                                                                                                                 |
+| `template`                 | set to `$METRIC_TEMPLATE` | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                                                                                               |
+| `help`                     | set to `$METRIC_HELP`     | no       | no       | see [metric name and help template system](#metric-name-and-help-template-system)                                                                                               |
 
 *Hint: Multiple values can be specified multiple times or with a comma in a single value.*
 

--- a/metrics/servicediscovery.go
+++ b/metrics/servicediscovery.go
@@ -70,6 +70,15 @@ func (sd *AzureServiceDiscovery) fetchResourceList(subscriptionId, filter string
 			for _, row := range result.Value {
 				resource := row
 
+				rt := sd.prober.settings.ResourceType
+				if rt != "" && resource.Type != nil && *resource.Type != rt {
+					// if ResourceType was configfured and the queried ResourceType
+					// does not match it, filter it out.
+					// we have to do this filtering locally due to ARM API limitations:
+					// https://github.com/Azure/azure-rest-api-specs/issues/21324
+					continue
+				}
+
 				resourceList = append(
 					resourceList,
 					AzureResource{

--- a/metrics/settings.go
+++ b/metrics/settings.go
@@ -53,8 +53,9 @@ func NewRequestMetricSettingsForAzureResourceApi(r *http.Request, opts config.Op
 	if r.URL.Path == config.ProbeMetricsResourceUrl {
 		return settings, nil
 	} else if settings.ResourceType != "" && settings.Filter != "" {
-		return settings, fmt.Errorf("parameter \"resourceType\" and \"filter\" are mutually exclusive")
+		return settings, nil
 	} else if settings.ResourceType != "" {
+		settings.ResourceType = ""
 		settings.Filter = fmt.Sprintf(
 			"resourceType eq '%s'",
 			strings.ReplaceAll(settings.ResourceType, "'", "\\'"),


### PR DESCRIPTION
    allow resourceType and filter to both be specified
    
    One quirk about the ARM resource list API is that the $filter
    specification requires the resourceType be used in very specific
    ways as hilighted in this issue:
    
      https://github.com/Azure/azure-rest-api-specs/issues/21324
    
    Due to that quick, azure-metrics-exporter disallowed scrape
    configs specifying both resourceType and filter.
    
    It would be useful to allow specifying both resourceType and
    filter for cases where the user wish to target only a subset
    of resources of a given type. The following example was a case
    where the user wanted to do that, but ended up working around
    the issue by using the substringof $filter keyword.
    
      https://github.com/webdevops/azure-metrics-exporter/issues/51
    
    The substringof $filter keyword only works for targetting
    resource name and resource group, and it does not work for
    targetting resource tag names or values.
    
    This update makes speciying both resourceType and filter to become
    allowed by filtering for the specified resourceType locally.
