### PR TITLE
improvement: Go mod webdevops/go-common version bump.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.20.3
 	github.com/remeh/sizedwaitgroup v1.0.0
-	github.com/webdevops/go-common v0.0.0-20240914143308-98dd8416e15d
+	github.com/webdevops/go-common v0.0.0-20241004201801-87c5aa8dbf70
 	go.uber.org/zap v1.27.0
 	go.uber.org/zap/exp v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/webdevops/go-common v0.0.0-20240914143308-98dd8416e15d h1:FPFH3gQwD9nAnxbXWJmN2SgLAIGhdlO2L5B+SzBTqlo=
-github.com/webdevops/go-common v0.0.0-20240914143308-98dd8416e15d/go.mod h1:7VI3uQs+oVv1sosA5/BNGInTCBWJ12xG1irqDheqUTQ=
+github.com/webdevops/go-common v0.0.0-20241004201801-87c5aa8dbf70 h1:nlbpXmLWrTypLZ7LoTrHrRGtT1eFwAbmQv72+wVEoYE=
+github.com/webdevops/go-common v0.0.0-20241004201801-87c5aa8dbf70/go.mod h1:7VI3uQs+oVv1sosA5/BNGInTCBWJ12xG1irqDheqUTQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=


### PR DESCRIPTION
## After this PR

This PR update to the latest commit webdevops/go-common which important contains the following PR: https://github.com/webdevops/go-common/pull/7.

Now a user can set `AZURE_ENVIRONMENT: AzureSecretCloud` and provide a corresponding `AZURE_CLOUD_CONFIG: <JSON>` or `AZURE_CLOUD_CONFIG_FILE: /path/to/file` with Azure secret cloud endpoints to have grafana-agent gather metrics from azure secret cloud regions.
